### PR TITLE
bug: fix command crashing

### DIFF
--- a/src/loadModules.js
+++ b/src/loadModules.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const subscriptions = new Map();
 
@@ -6,7 +6,7 @@ export default async (client) => {
     /**
      * loads all modules and their subscriptions
      */
-    const modules = fs.readdirSync('./src/modules');
+    const modules = await fs.readdir('./src/modules');
 
     await Promise.all(
         modules.map(async (moduleName) => {

--- a/src/modules/inlineCommands/commands/choose.js
+++ b/src/modules/inlineCommands/commands/choose.js
@@ -14,7 +14,7 @@ async function fun(client, message) {
     if (!amount) return;
     for (let i = 1; i < amount + 1; i += 1) {
         // eslint-disable-next-line no-await-in-loop
-        await message.react(getEmoji(client, `_${i}`));
+        await message.react(getEmoji(`_${i}`));
     }
 }
 

--- a/src/modules/inlineCommands/module.js
+++ b/src/modules/inlineCommands/module.js
@@ -5,15 +5,15 @@ import {
 } from './processCommands';
 
 function messageCreate(client, message) {
-    processCommandsNewMessage(client, message);
+    return processCommandsNewMessage(client, message);
 }
 
 function messageEdit(client, messageOld, messageNew) {
-    processCommandsEditMessage(client, messageOld, messageNew);
+    return processCommandsEditMessage(client, messageOld, messageNew);
 }
 
 function ready() {
-    loadCommands();
+    return loadCommands();
 }
 
 const subscriptions = new Map();


### PR DESCRIPTION
Commands now pass errors upwards to error handler.
Fixed incorrect usage of getEmoji causing a crash.
Move to fs/promises instead of fs sync.