### PR TITLE
fix: dm crash

### DIFF
--- a/src/modules/automod/message.js
+++ b/src/modules/automod/message.js
@@ -105,6 +105,8 @@ async function handlePings(client, message) {
  */
 export async function messageCreate(client, message) {
     if (message.author.bot) return;
+    // If this is a DM we can ignore these
+    if (!message.guild) return;
     await handleSwearing(client, message);
     await handlePings(client, message);
 }

--- a/src/modules/autoresponses/textResponses.js
+++ b/src/modules/autoresponses/textResponses.js
@@ -8,6 +8,8 @@ import Emotes from '../../constants/Emotes';
  * @return {Promise<void>}
  */
 export async function messageCreate(client, message) {
+    // No auto responses in dm's
+    if (!message.guild) return;
     await Promise.all(
         responseDb.map(async (responseDto) => {
             const triggers = responseDto.trigger.some((trigger) =>

--- a/src/modules/inlineCommands/processCommands.js
+++ b/src/modules/inlineCommands/processCommands.js
@@ -32,6 +32,8 @@ async function loadCommands() {
 async function processCommandsNewMessage(client, message) {
     // Avoid botception
     if (message.author.bot) return;
+    // No inline commands in DM's
+    if (!message.guild) return;
     await Promise.all(
         commands.map((fun, command) => {
             if (message.content.match(command) !== null) {


### PR DESCRIPTION
Just don't run the ping or swearing checks in dm's.
Also ignores dm's for inline commands and auto responses.

Fixes #50.
