### PR TITLE
fix: undefined or null users when getting xp

### DIFF
--- a/src/modules/leveling/awards/reactions.js
+++ b/src/modules/leveling/awards/reactions.js
@@ -38,7 +38,7 @@ export default async function messageReactionAdd(client, messageReaction, user) 
 
     const member = await message.guild.members.fetch(user.id);
 
-    if(!message.member) await message.guild.members.fetch(message.author);
+    if (!message.member) await message.guild.members.fetch(message.author);
 
     await member.roles.add(getRole(`cooldown_${reactionName}`));
 


### PR DESCRIPTION
This should fix #23.
Also fixes an unkown issue I wasn't aware of trying to find that issue.