### PR TITLE
feat: better auto mod

### DIFF
--- a/src/constants/Blacklist.js
+++ b/src/constants/Blacklist.js
@@ -57,6 +57,5 @@ const swearRegex = new RegExp(
     )})`
 );
 export default {
-    swearWords,
     swearRegex,
 };

--- a/src/modules/automod/message.js
+++ b/src/modules/automod/message.js
@@ -34,7 +34,6 @@ async function handleSwearing(client, message) {
             userDto.swearlevel = 0; // resets the swear level, if time ran out
         }
         userDto.swearlevel += 1;
-        message.delete().catch((e) => console.error('Error deleting swear', e));
         switch (userDto.swearlevel) {
             case 1:
                 await message.author


### PR DESCRIPTION
Auto mod now ensures that swears are only detected if the word starts with the swear.
Made regex swears use non-capturing groups (they are faster).
Allows swears to have spaces between them.
Pre-process the swear regex so that it is not processed wach time.

This has been tested on all of our know false positives and no longer triggers.

Close #82