### PR TITLE
fix: move error and error handling error

### DIFF
--- a/src/modules/modCommands/commands/move.js
+++ b/src/modules/modCommands/commands/move.js
@@ -84,8 +84,14 @@ const move = async (message, limit, channel, after = null) => {
         // eslint-disable-next-line no-await-in-loop
         await channel.send({ embeds });
     }
-    await message.channel.bulkDelete(msg);
-    return message.channel.send(`Successfully moved \`${msg.size}\` messages to ${channel}!`);
+    const deleted = await message.channel.bulkDelete(msg, true);
+    return message.channel.send(
+        `Successfully moved \`${msg.size}\` messages to ${channel}!${
+            deleted.size === msg.size
+                ? ''
+                : ` Not all messages were able to be deleted. Please delete these messages manually.`
+        }`
+    );
 };
 
 /**

--- a/src/modules/modCommands/processCommands.js
+++ b/src/modules/modCommands/processCommands.js
@@ -50,9 +50,14 @@ async function processCommandsNewMessage(client, message) {
         await cmd.fun(client, message, args, level);
     } catch (e) {
         console.error(`Error running command "${command}":\n${e?.stack || e}`);
-        message
-            .reply(`Something went wrong processing that command! Please try again later.`)
-            .catch((err) => console.error('Error sending error!\n', err));
+        if (message.deleted)
+            message.channel
+                .send(`Something went wrong processing that command! Please try again later.`)
+                .catch((err) => console.error('Error sending error!\n', err));
+        else
+            message
+                .reply(`Something went wrong processing that command! Please try again later.`)
+                .catch((err) => console.error('Error sending error!\n', err));
     }
 }
 


### PR DESCRIPTION
This fixes move crashing when deleting messages older than two weeks, and displays a message saying it couldn't delete all messages.
Also causes the error handler to not error if the original message was deleted.