### PR TITLE
fix: stop crashing on leaderboard update errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .env
     volumes:
       - data:/app/data
-    restart: unless-stopped
+    restart: on-failure:5
     stop_grace_period: 10s
 
 volumes:

--- a/src/modules/activityLeaderboard/module.js
+++ b/src/modules/activityLeaderboard/module.js
@@ -59,8 +59,13 @@ const updateAwards = () => {
     return Promise.all(res);
 };
 
-const updateLeaderboards = () =>
-    Promise.all([updateActivity(), updateLeaderboard(), updateAwards()]);
+const updateLeaderboards = async () => {
+    (await Promise.allSettled([updateActivity(), updateLeaderboard(), updateAwards()])).forEach(
+        (s) => {
+            if (s.status === 'rejected') console.error('Error updating leaderboards:\n', s.reason);
+        }
+    );
+};
 
 subscriptions.set('ready', async () => {
     setInterval(async () => {

--- a/src/modules/errorHandling/module.js
+++ b/src/modules/errorHandling/module.js
@@ -1,3 +1,5 @@
+import './unhandledError';
+
 /**
  * Function called, when an error occurred while executing an event.
  * prints out the stacktrace.

--- a/src/modules/errorHandling/unhandledError.js
+++ b/src/modules/errorHandling/unhandledError.js
@@ -1,0 +1,10 @@
+import { getClient } from '../../util';
+
+process.on('uncaughtException', (err) => {
+    console.error('Uncaught Error!!!!\nSomebody better fix this!!!');
+    console.error(err);
+    if (getClient()?.uptime < 1) {
+        console.log("Client doesn't seem to be up. Killing bot!!!");
+        process.exit(1);
+    }
+});

--- a/src/util.js
+++ b/src/util.js
@@ -256,6 +256,7 @@ const factionDb = new Enmap({
     name: 'factions',
     serializer,
     deserializer: deserializerFactionDto,
+    autoEnsure: new FactionDto(),
 });
 
 export {


### PR DESCRIPTION
Docker now stops retrying after 5 crashes
UpdateLeaderboards now handles multiple errors.
Unhandled errors now do a (semi)-graceful shutdown
FactonDb has default.