### PR TITLE
fix: more false positives with ass

### DIFF
--- a/src/constants/Blacklist.js
+++ b/src/constants/Blacklist.js
@@ -3,7 +3,7 @@
  */
 const swearWords = [
     'ar+s+e(?:\\s|$)', // This one has the thing at the end cause it triggers on the //ar set command
-    'ass',
+    'ass\\b',
     'anal',
     'anus',
     'boo+b',


### PR DESCRIPTION
This makes it where it can only match `ass` now. Assume will no longer trigger this.