### PR TITLE
feat: notificationpings

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -36,7 +36,7 @@ export default async function sendLevelNotification(member, level) {
 
     await member.fetch(false);
     return replaceAndSend(levelMessages[messageIndex], {
-        name: `**${member.displayName}**`,
+        name: `**${level < 20? member.displayName: member}**`,
         level: `**Level ${level}**`,
     });
 }

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -36,7 +36,7 @@ export default async function sendLevelNotification(member, level) {
 
     await member.fetch(false);
     return replaceAndSend(levelMessages[messageIndex], {
-        name: `**${level < 20? member.displayName: member}**`,
+        name: `**${level < 20 ? member.displayName : member}**`,
         level: `**Level ${level}**`,
     });
 }


### PR DESCRIPTION
isaac requested that level ups should ping from level 40-50 upwards. (in case they open an issue, i'll link it)
i think level 20 is more reasonable, as level ups slow down enough starting then.

Jwiggs: request is not for technical stuff but if it is ok if ppl get pinged starting then or if you would prefer a different start point