### PR TITLE
fix: swearing

### DIFF
--- a/src/constants/Blacklist.js
+++ b/src/constants/Blacklist.js
@@ -4,7 +4,6 @@
 const swearWords = [
     'ar+s+e(?:\\s|$)', // This one has the thing at the end cause it triggers on the //ar set command
     'ass\\b',
-    'anal',
     'anus',
     'boo+b',
     'bitch',

--- a/src/modules/automod/message.js
+++ b/src/modules/automod/message.js
@@ -42,7 +42,7 @@ async function handleSwearing(client, message) {
         const userDto = userDb.get(message.author.id);
         const now = Date.now();
         const cooldown = userDto.cooldown.get('swearing');
-        if (now > cooldown) {
+        if (now > (cooldown || 0)) {
             userDto.swearlevel = 0; // resets the swear level, if time ran out
         }
         userDto.swearlevel += 1;


### PR DESCRIPTION
Swears now reset properly on reboots.
Removed anal cause it has too many false positives.
(e.g. analize, an alt, analytics, an already)