### PR TITLE
chore: add backups to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
 
 volumes:
   data:
+  backups:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - .env
     volumes:
       - data:/app/data
+      - backups:/app/backups
     restart: on-failure:5
     stop_grace_period: 10s
 


### PR DESCRIPTION
This allows users to be able to import/export backups to a docker image.
This also allows backups to persist through container updates.