### PR TITLE
feat: pin reaction

### DIFF
--- a/src/modules/inlineCommands/processCommands.js
+++ b/src/modules/inlineCommands/processCommands.js
@@ -52,6 +52,7 @@ async function processCommandsNewMessage(client, message) {
  */
 async function processCommandsEditMessage(client, oldMessage, newMessage) {
     if (newMessage.partial) newMessage = await newMessage.fetch();
+    if (!newMessage.editedTimestamp || Date.now() - newMessage.editedTimestamp > 3000) return;
     await processCommandsNewMessage(client, newMessage);
 }
 

--- a/src/modules/reactionCommands/module.js
+++ b/src/modules/reactionCommands/module.js
@@ -1,0 +1,8 @@
+import messageReactionAdd from './processReactions';
+
+const subscriptions = new Map();
+subscriptions.set('messageReactionAdd', messageReactionAdd);
+
+const enabled = true;
+
+export { subscriptions, enabled };

--- a/src/modules/reactionCommands/processReactions.js
+++ b/src/modules/reactionCommands/processReactions.js
@@ -1,0 +1,42 @@
+import config from '../../config';
+import Emotes from '../../constants/Emotes';
+import { pin } from '../../permissions';
+import { getMember } from '../../util';
+
+/**
+ *
+ * @param {import('discord.js').Client} client
+ * @param {import('discord.js').MessageReaction} messageReaction
+ * @param {import('discord.js').User} user
+ * @return {Promise<void>}
+ */
+export default async function messageReactionAdd(client, messageReaction, user) {
+    let users;
+    let msg;
+    if (messageReaction.partial) {
+        messageReaction = await messageReaction.fetch();
+        msg = await messageReaction.message.fetch();
+        users = await messageReaction.users.fetch();
+    } else {
+        users = messageReaction.users.cache;
+        msg = messageReaction.message;
+    }
+    if (user.partial) user = await user.fetch();
+    if (user.id === client.user.id || msg.guildId !== config.defaultGuild) return;
+    switch (messageReaction.emoji.name) {
+        case Emotes.pin:
+            if (!pin(await getMember(user.id))) return;
+            if (msg.pinned) {
+                await msg.unpin();
+                if (users.has(client.user.id)) await messageReaction.users.remove();
+                await messageReaction.users.remove(user);
+            } else {
+                await msg.pin();
+                await msg.react(Emotes.pin);
+                await messageReaction.users.remove(user);
+            }
+            break;
+        default:
+            break;
+    }
+}


### PR DESCRIPTION
Toggles message pin status
Made inline commands only toggle after edits (prevents <pin> messages from repinning on unpin).

Also is 3 seconds good for inline edits? 